### PR TITLE
Feature - Normalized API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added .NET 7 support
-- Added feature to remove all leading and trailing white-space characters from the String object representing the number w/ and w/o check digit.
+- Added feature to remove all leading and trailing white-space characters from the String object representing a number w/ and w/o Luhn check digit.
+- Added an overload of the `Luhn.IsValid` method to accept a String object representing a number w/o Luhn check digit. The check digit is separated from the number as single byte parameter.
+- Added `Luhn.ComputeCheckDigit` method to compute the Luhn check digit.
+- Added `Luhn.ComputeLuhnNumber` method to compute the Luhn number.
 
 ### Changed
 - Updated Microsoft.NETFramework.ReferenceAssemblies to v1.0.3
+
+### Deprecated
+- `Luhn.Compute()` method is deprecated. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber() instead`.
 
 ### Removed
 - Removed LINQ dependency

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ An C# implementation of the Luhn algorithm.
    You can open the `.csproj` file to check the deleted package reference.
 
 # Usage
-## Compute the check digit
+## Compute the Luhn check digit
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -142,7 +142,7 @@ namespace Example1
   {
     public static void Main(string[] args)
     {
-      var checkDigit = Luhn.Compute("37828224631000");
+      var checkDigit = Luhn.ComputeLuhnCheckDigit("37828224631000");
       //// Must be 5
       Console.WriteLine(checkDigit);
     }
@@ -150,7 +150,7 @@ namespace Example1
 }
 ```
 
-## Validate number
+## Compute the Luhn number
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -162,7 +162,47 @@ namespace Example2
   {
     public static void Main(string[] args)
     {
+      var luhnNumber = Luhn.ComputeLuhnNumber("37828224631000");
+      //// Must be 378282246310005
+      Console.WriteLine(luhnNumber);
+    }
+  }
+}
+```
+
+## Validate Luhn number
+```csharp
+using System;
+using System.Collections.Generic;
+using LuhnDotNet;
+
+namespace Example3
+{
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
       var isValid = Luhn.IsValid("378282246310005");
+      //// Must be 'true'
+      Console.WriteLine(isValid);
+    }
+  }
+}
+```
+
+## Validate number and corresponding Luhn check digit
+```csharp
+using System;
+using System.Collections.Generic;
+using LuhnDotNet;
+
+namespace Example4
+{
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
+      var isValid = Luhn.IsValid("37828224631000", 5);
       //// Must be 'true'
       Console.WriteLine(isValid);
     }

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -11,29 +11,61 @@ namespace LuhnDotNetTest
     public class LuhnTest
     {
         /// <summary>
-        /// Test numbers without check digit.
+        /// Valid raw test numbers without check digit.
         /// </summary>
-        public static IEnumerable<object[]> RawNumbers =>
+        public static IEnumerable<object[]> LuhnCheckDigitComputeSet =>
             new List<object[]>
             {
                 new object[] { 3, "7992739871" },
+                new object[] { 3, "07992739871" },
+                new object[] { 3, "007992739871" },
                 new object[] { 2, "110494" },
                 new object[] { 5, "37828224631000" },
                 new object[] { 5, "637095000000000" },
+                new object[] { 5, " 637095000000000" },
+                new object[] { 5, "637095000000000 " },
+                new object[] { 5, " 637095000000000 " },
                 new object[] { 3, "89999912345678901" },
+                new object[] { 3, "  89999912345678901" },
             };
 
         /// <summary>
-        /// Test numbers with check digit.
+        /// Valid raw test numbers without check digit.
         /// </summary>
-        public static IEnumerable<object[]> LuhnNumbers =>
+        public static IEnumerable<object[]> LuhnNumberComputeSet =>
+            new List<object[]>
+            {
+                new object[] { "79927398713", "7992739871" },
+                new object[] { "079927398713", "07992739871" },
+                new object[] { "0079927398713", "007992739871" },
+                new object[] { "1104942", "110494" },
+                new object[] { "378282246310005", "37828224631000" },
+                new object[] { "6370950000000005", "637095000000000" },
+                new object[] { "6370950000000005", " 637095000000000" },
+                new object[] { "6370950000000005", "637095000000000 " },
+                new object[] { "6370950000000005", " 637095000000000 " },
+                new object[] { "899999123456789013", "89999912345678901" },
+                new object[] { "899999123456789013", "  89999912345678901" },
+            };
+
+        /// <summary>
+        /// Test numbers with w/ and w/o valid check digit (Luhn numbers).
+        /// </summary>
+        public static IEnumerable<object[]> LuhnNumberValidationSet =>
             new List<object[]>
             {
                 new object[] { true, "79927398713" },
+                new object[] { true, "0079927398713" },
+                new object[] { true, "079927398713" },
                 new object[] { true, "1104942" },
+                new object[] { true, "01104942" },
                 new object[] { true, "378282246310005" },
                 new object[] { true, "6370950000000005" },
+                new object[] { true, " 6370950000000005" },
+                new object[] { true, "6370950000000005 " },
+                new object[] { true, " 6370950000000005 " },
                 new object[] { true, "899999123456789013" },
+                new object[] { true, "   899999123456789013" },
                 new object[] { false, "79927398717" },
                 new object[] { false, "1104945" },
                 new object[] { false, "378282246310001" },
@@ -42,7 +74,33 @@ namespace LuhnDotNetTest
             };
 
         /// <summary>
-        /// Invalid numbers.
+        /// Test numbers with separate valid and invalid check digits.
+        /// </summary>
+        public static IEnumerable<object[]> LuhnCheckDigitValidationSet =>
+            new List<object[]>
+            {
+                new object[] { true, "7992739871", 3 },
+                new object[] { true, "07992739871", 3 },
+                new object[] { true, "007992739871", 3 },
+                new object[] { true, "0007992739871", 3 },
+                new object[] { true, "110494", 2 },
+                new object[] { true, "37828224631000", 5 },
+                new object[] { true, "637095000000000", 5 },
+                new object[] { true, " 637095000000000", 5 },
+                new object[] { true, "637095000000000 ", 5 },
+                new object[] { true, " 637095000000000 ", 5 },
+                new object[] { true, "89999912345678901", 3 },
+                new object[] { true, "   89999912345678901", 3 },
+                new object[] { false, "7992739871", 7 },
+                new object[] { false, "110494", 5 },
+                new object[] { false, "37828224631000", 1 },
+                new object[] { false, "637095000000000", 7 },
+                new object[] { false, "89999912345678901", 9 },
+            };
+
+        
+        /// <summary>
+        /// Invalid test numbers.
         /// </summary>
         public static IEnumerable<object[]> InvalidNumbers =>
             new List<object[]>
@@ -51,46 +109,129 @@ namespace LuhnDotNetTest
                 new object[] { string.Empty },
                 new object[] { "ABC" },
                 new object[] { "?11243345" },
+                new object[] { "_-%&" },
+            };
+        
+        /// <summary>
+        /// Invalid numbers and check digits.
+        /// </summary>
+        public static IEnumerable<object[]> InvalidNumbersAndCheckDigits =>
+            new List<object[]>
+            {
+                new object[] { "%&/" , 1},
+                new object[] { "_-:,", 2 },
+                new object[] { "ABC", 3},
+                new object[] { "?11243345", 4 },
+            };
+        
+        /// <summary>
+        /// Test numbers and invalid separate check digits.
+        /// </summary>
+        public static IEnumerable<object[]> NumbersWithInvalidCheckDigits =>
+            new List<object[]>
+            {
+                new object[] { "637095000000000" , 10},
+                new object[] { "110494", 11 },
+                new object[] { "7992739871", 12},
+                new object[] { "?89999912345678901", 13 },
             };
 
         /// <summary>
-        /// 
+        /// Tests the Luhn check digit calculation.
         /// </summary>
         /// <param name="expectedCheckDigit">Expected check digit</param>
         /// <param name="rawNumber">Test number exclusive check digit</param>
-        [Theory(DisplayName = "Calculate the check digit for a valid number")]
-        [MemberData(nameof(RawNumbers), MemberType = typeof(LuhnTest))]
-        public void LuhnComputeTest(byte expectedCheckDigit, string rawNumber) =>
-            Assert.Equal(expectedCheckDigit, Compute(rawNumber));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="expectedResult">Expected validation result</param>
-        /// <param name="luhnNumber">Test number inclusive check digit</param>
-        [Theory(DisplayName = "Validate a number containing a check digit")]
-        [MemberData(nameof(LuhnNumbers), MemberType = typeof(LuhnTest))]
-        public void LuhnValidationTest(bool expectedResult, string luhnNumber) =>
-            Assert.Equal(expectedResult, IsValid(luhnNumber));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Theory(DisplayName = "Calculate the check digit for an invalid number to throw an exception")]
-        [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
-        public void ComputeExceptionTest(string invalidNumber)
+        [Theory(DisplayName = "Calculates the check digit for a valid raw number")]
+        [MemberData(nameof(LuhnCheckDigitComputeSet), MemberType = typeof(LuhnTest))]
+        public void ComputeLuhnCheckDigitTest(byte expectedCheckDigit, string rawNumber)
         {
-            Assert.Throws<ArgumentException>(() => Compute(invalidNumber));
+            Assert.Equal(expectedCheckDigit, Compute(rawNumber));
+            Assert.Equal(expectedCheckDigit, ComputeLuhnCheckDigit(rawNumber));
         }
 
         /// <summary>
-        /// 
+        /// Tests the Luhn number calculation.
         /// </summary>
-        [Theory(DisplayName = "Validate an invalid number to throw an exception")]
+        /// <param name="expectedLuhnNumber">Expected check digit</param>
+        /// <param name="rawNumber">Test number exclusive check digit</param>
+        [Theory(DisplayName = "Calculates the Luhn number for a valid raw number")]
+        [MemberData(nameof(LuhnNumberComputeSet), MemberType = typeof(LuhnTest))]
+        public void ComputeLuhnNumberTest(string expectedLuhnNumber, string rawNumber) => 
+            Assert.Equal(expectedLuhnNumber, ComputeLuhnNumber(rawNumber));
+
+        /// <summary>
+        /// Tests Luhn number validation.
+        /// </summary>
+        /// <param name="expectedResult">Expected validation result</param>
+        /// <param name="luhnNumber">Test number inclusive check digit</param>
+        [Theory(DisplayName = "Validates a number containing a check digit")]
+        [MemberData(nameof(LuhnNumberValidationSet), MemberType = typeof(LuhnTest))]
+        public void LuhnNumberValidationTest(bool expectedResult, string luhnNumber) =>
+            Assert.Equal(expectedResult, IsValid(luhnNumber));
+
+        /// <summary>
+        /// Tests number validation with separate check digit.
+        /// </summary>
+        /// <param name="expectedResult">Expected validation result</param>
+        /// <param name="number">Test number exclusive check digit</param>
+        /// <param name="checkDigit">Test Luhn check digit</param>
+        [Theory(DisplayName = "Validates a number with separate check digit between 0 and 9")]
+        [MemberData(nameof(LuhnCheckDigitValidationSet), MemberType = typeof(LuhnTest))]
+        public void LuhnCheckDigitValidationTest(bool expectedResult, string number, byte checkDigit) =>
+            Assert.Equal(expectedResult, IsValid(number, checkDigit));
+
+        /// <summary>
+        /// Tests whether or not a exception is thrown when an invalid raw number is passed to the Luhn check
+        /// digit algorithm. 
+        /// </summary>
+        [Theory(DisplayName = "Calculates the check digit for an invalid raw number to throw an exception")]
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
-        public void ValidationExceptionTest(string invalidNumber)
+        public void ComputeCheckDigitExceptionTest(string invalidNumber)
+        {
+            Assert.Throws<ArgumentException>(() => Compute(invalidNumber));
+            Assert.Throws<ArgumentException>(() => ComputeLuhnCheckDigit(invalidNumber));
+        }
+
+        /// <summary>
+        /// Tests whether or not a exception is thrown when an invalid raw number is passed to the Luhn
+        /// number algorithm. 
+        /// </summary>
+        [Theory(DisplayName = "Calculates the Luhn number for an invalid raw number to throw an exception")]
+        [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
+        public void ComputeLuhnNumberExceptionTest(string invalidNumber) => 
+            Assert.Throws<ArgumentException>(() => ComputeLuhnNumber(invalidNumber));
+
+        /// <summary>
+        /// Tests whether or not a exception is thrown when an invalid Luhn number is passed to the Luhn
+        /// validation algorithm.
+        /// </summary>
+        [Theory(DisplayName = "Validates an invalid Luhn number (e.g. none-numeric characters) to throw an exception")]
+        [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
+        public void LuhnNumberValidationExceptionTest(string invalidNumber)
         {
             Assert.Throws<ArgumentException>(() => IsValid(invalidNumber));
+        }
+
+        /// <summary>
+        /// Tests whether or not a exception is thrown when an invalid number and check digit between 0 and 9
+        /// is passed to the Luhn validation algorithm.
+        /// </summary>
+        [Theory(DisplayName = "Validates an invalid number with any check digit between 0 and 9 to throw an exception")]
+        [MemberData(nameof(InvalidNumbersAndCheckDigits), MemberType = typeof(LuhnTest))]
+        public void NumberValidationExceptionTest(string invalidNumber, byte checkDigit)
+        {
+            Assert.Throws<ArgumentException>(() => IsValid(invalidNumber, checkDigit));
+        }
+
+        /// <summary>
+        /// Tests whether or not a exception is thrown when an invalid check digit (greater tah 9) is passed to the
+        /// Luhn validation algorithm.
+        /// </summary>
+        [Theory(DisplayName = "Validates a number with separate check digit greater than 9 to throw an exception")]
+        [MemberData(nameof(NumbersWithInvalidCheckDigits), MemberType = typeof(LuhnTest))]
+        public void LuhnCheckDigitValidationExceptionTest(string invalidNumber, byte checkDigit)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => IsValid(invalidNumber, checkDigit));
         }
     }
 }


### PR DESCRIPTION
### Added
- Added an overload of the `Luhn.IsValid` method to accept a String object representing a number w/o Luhn check digit. The check digit is separated from the number as single byte parameter.
- Added `Luhn.ComputeCheckDigit` method to compute the Luhn check digit.
- Added `Luhn.ComputeLuhnNumber` method to compute the Luhn number.

### Deprecated
- `Luhn.Compute()` method is deprecated. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber() instead`.
