### PR TITLE
Obsolete  - Compute-Method is EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed parameter type of `Luhn.IsValid`, `Luhn.ComputeLuhnNumber` and `Luhn.ComputeCheckDigit` methods from `string` to `ReadOnlySpan<char>`.
 
+### Deprecated
+- `Luhn.Compute()` method is EOL and will be deleted in the next version. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber() instead`.
+
 ## [0.2.0] - 2022-12-18
 ### Added
 - Added .NET 7 support

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -57,7 +57,7 @@ namespace LuhnDotNet
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn check digit.</returns>
         /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid luhnNumber</exception>
-        [Obsolete("Use Luhn.CalculateCheckDigit instead", false)]
+        [Obsolete("Use Luhn.CalculateCheckDigit instead", true)]
         public static byte Compute(string number) => ComputeLuhnCheckDigit(number);
 
         /// <summary>

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -145,7 +145,6 @@ namespace LuhnDotNetTest
         [MemberData(nameof(LuhnCheckDigitComputeSet), MemberType = typeof(LuhnTest))]
         public void ComputeLuhnCheckDigitTest(byte expectedCheckDigit, string rawNumber)
         {
-            Assert.Equal(expectedCheckDigit, Compute(rawNumber));
             Assert.Equal(expectedCheckDigit, ComputeLuhnCheckDigit(rawNumber));
         }
 
@@ -188,7 +187,6 @@ namespace LuhnDotNetTest
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
         public void ComputeCheckDigitExceptionTest(string invalidNumber)
         {
-            Assert.Throws<ArgumentException>(() => Compute(invalidNumber));
             Assert.Throws<ArgumentException>(() => ComputeLuhnCheckDigit(invalidNumber));
         }
 


### PR DESCRIPTION
### Deprecated
- `Luhn.Compute()` method is EOL and will be deleted in the next version. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber() instead`.
