### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2024-02-19
 ### Added
 - Added .NET 8 support
 - Added support for SourceLink (GitHub)
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed parameter type of `Luhn.IsValid`, `Luhn.ComputeLuhnNumber` and `Luhn.ComputeCheckDigit` methods from `string` to `ReadOnlySpan<char>`.
 
 ### Deprecated
-- `Luhn.Compute()` method is EOL and will be deleted in the next version. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber() instead`.
+- `Luhn.Compute()` method is EOL and will be deleted in the next version. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber()` instead.
 
 ## [0.2.0] - 2022-12-18
 ### Added
@@ -38,6 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added initial version of LuhnDotNet
 
-[Unreleased]: https://github.com/shinji-san/LuhnDotNet/compare/v0.1.0...HEAD
+[1.0.0]: https://github.com/shinji-san/LuhnDotNet/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/shinji-san/LuhnDotNet/compare/v0.1.0..v0.2.0
 [0.1.0]: https://github.com/shinji-san/LuhnDotNet/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An C# implementation of the Luhn algorithm.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href ="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
-          <td rowspan=9><code>LuhnDotNet.sln</code></td>
-          <td rowspan=9>SDK</td>
+          <td rowspan=10><a href ="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=10><code>LuhnDotNet.sln</code></td>
+          <td rowspan=10>SDK</td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -42,6 +42,9 @@ An C# implementation of the Luhn algorithm.
       <tr>
           <td>.NET 7</td>
       </tr>
+      <tr>
+          <td>.NET 8</td>
+      </tr>
   </tbody>
 </table>
 
@@ -58,13 +61,16 @@ An C# implementation of the Luhn algorithm.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20NuGet/badge.svg?branch=v0.2.0" alt="LuhnDotNet NuGet"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/LuhnDotNet" target="_blank"><img src="https://badge.fury.io/nu/LuhnDotNet.svg" alt="NuGet Version 0.2.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/tree/v0.2.0" target="_blank"><img src="https://img.shields.io/badge/LuhnDotNet-0.2.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20NuGet/badge.svg?branch=v1.0.0" alt="LuhnDotNet NuGet"/></a></td>
+          <td rowspan=10><a href="https://badge.fury.io/nu/LuhnDotNet" target="_blank"><img src="https://badge.fury.io/nu/LuhnDotNet.svg" alt="NuGet Version 1.0.0"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/LuhnDotNet/tree/v1.0.0" target="_blank"><img src="https://img.shields.io/badge/LuhnDotNet-1.0.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>.NET 6</td>
       </tr>
       <tr>
           <td>.NET 7</td>
+      </tr>
+      <tr>
+          <td>.NET 8</td>
       </tr>
       <tr>
           <td>Standard 2.0</td>
@@ -94,10 +100,10 @@ An C# implementation of the Luhn algorithm.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.2.0 of the LuhnDotNet package:
+2. Use the following command to install version 1.0.0 of the LuhnDotNet package:
 
     ```dotnetcli
-    dotnet add package LuhnDotNet -v 0.2.0 -f <FRAMEWORK>
+    dotnet add package LuhnDotNet -v 1.0.0 -f <FRAMEWORK>
     ```
 
 3. After the completition of the command, look at the project file to make sure that the package is successfuly installed.
@@ -106,7 +112,7 @@ An C# implementation of the Luhn algorithm.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="LuhnDotNet" Version="0.2.0" />
+      <PackageReference Include="LuhnDotNet" Version="1.0.0" />
     </ItemGroup>
     ```
 ## Remove LuhnDotNet package
@@ -206,7 +212,7 @@ namespace Example4
 
 # CLI building instructions
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
-## Using dotnet to build for .NET 6, .NET 7 and .NET FX 4.x
+## Using dotnet to build for .NET 6, .NET 7, .NET 8 and .NET FX 4.x
 Use one of the following solutions with `dotnet` to build [LuhnDotNet](#luhndotnet):
 * `LuhnDotNet.sln` (all, [see table](#build--test-status-of-default-branch))
 

--- a/src/LuhnDotNet.csproj
+++ b/src/LuhnDotNet.csproj
@@ -10,13 +10,14 @@
         <Authors>Sebastian Walther</Authors>
         <PackageId>LuhnDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/LuhnDotNet/blob/v1.0.0/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of the Luhn algorithm</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>luhn;luhn-algorithm</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/LuhnDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/LuhnDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>0.2.0</Version>
+        <Version>1.0.0</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("bba40d96-b58d-4a8f-b6fc-3699e0addf98")]
 
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyFileVersion("0.2.0")]
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]


### PR DESCRIPTION
### Added
- Added .NET 8 support
- Added support for SourceLink (GitHub)
- Enable deterministic builds

### Changed
- Changed parameter type of `Luhn.IsValid`, `Luhn.ComputeLuhnNumber` and `Luhn.ComputeCheckDigit` methods from `string` to `ReadOnlySpan<char>`.

### Deprecated
- `Luhn.Compute()` method is EOL and will be deleted in the next version. Use `Luhn.ComputeCheckDigit()` or `Luhn.ComputeLuhanNumber()` instead.
