### PR TITLE
Fix - Luhn check digit calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed a bug in `Luhn.ComputeLuhnNumber` and `Luhn.ComputeLuhnCheckDigit` methods that sometimes returned an incorrect result.
+
 ## [1.0.0] - 2024-02-19
 ### Added
 - Added .NET 8 support

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -73,7 +73,7 @@ namespace LuhnDotNet
 #else
         public static byte ComputeLuhnCheckDigit(string number) =>
 #endif
-            (byte)(Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits());
+            (byte)((Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
 
         /// <summary>
         /// Computes the Luhn number which is a combination of the given number and the calculated check digit.
@@ -89,7 +89,7 @@ namespace LuhnDotNet
         public static string ComputeLuhnNumber(string number)
 #endif
         {
-            byte checkDigit = (byte)(Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits());
+            byte checkDigit = (byte)((Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
 #if NET6_0_OR_GREATER
             return string.Concat(number.Trim(), checkDigit.ToString(CultureInfo.InvariantCulture));
 #else

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -16,10 +16,13 @@ namespace LuhnDotNetTest
         public static IEnumerable<object[]> LuhnCheckDigitComputeSet =>
             new List<object[]>
             {
+                new object[] { 4, "1789372997" },
+                new object[] { 0, "353011133330000" },
                 new object[] { 3, "7992739871" },
                 new object[] { 3, "07992739871" },
                 new object[] { 3, "007992739871" },
                 new object[] { 2, "110494" },
+                new object[] { 7, "1893" },
                 new object[] { 5, "37828224631000" },
                 new object[] { 5, "637095000000000" },
                 new object[] { 5, " 637095000000000" },
@@ -35,10 +38,13 @@ namespace LuhnDotNetTest
         public static IEnumerable<object[]> LuhnNumberComputeSet =>
             new List<object[]>
             {
+                new object[] { "17893729974", "1789372997" },
+                new object[] { "3530111333300000", "353011133330000" },
                 new object[] { "79927398713", "7992739871" },
                 new object[] { "079927398713", "07992739871" },
                 new object[] { "0079927398713", "007992739871" },
                 new object[] { "1104942", "110494" },
+                new object[] { "18937", "1893" },
                 new object[] { "378282246310005", "37828224631000" },
                 new object[] { "6370950000000005", "637095000000000" },
                 new object[] { "6370950000000005", " 637095000000000" },
@@ -54,10 +60,13 @@ namespace LuhnDotNetTest
         public static IEnumerable<object[]> LuhnNumberValidationSet =>
             new List<object[]>
             {
+                new object[] { true, "17893729974" },
+                new object[] { true, "3530111333300000" },
                 new object[] { true, "79927398713" },
                 new object[] { true, "0079927398713" },
                 new object[] { true, "079927398713" },
                 new object[] { true, "1104942" },
+                new object[] { true, "18937" },
                 new object[] { true, "01104942" },
                 new object[] { true, "378282246310005" },
                 new object[] { true, "6370950000000005" },
@@ -79,11 +88,14 @@ namespace LuhnDotNetTest
         public static IEnumerable<object[]> LuhnCheckDigitValidationSet =>
             new List<object[]>
             {
+                new object[] { true, "1789372997", 4 },
+                new object[] { true, "353011133330000", 0 },
                 new object[] { true, "7992739871", 3 },
                 new object[] { true, "07992739871", 3 },
                 new object[] { true, "007992739871", 3 },
                 new object[] { true, "0007992739871", 3 },
                 new object[] { true, "110494", 2 },
+                new object[] { true, "1893", 7 },
                 new object[] { true, "37828224631000", 5 },
                 new object[] { true, "637095000000000", 5 },
                 new object[] { true, " 637095000000000", 5 },


### PR DESCRIPTION
### Fixed
- Fixed a bug in `Luhn.ComputeLuhnNumber` and `Luhn.ComputeLuhnCheckDigit` methods that sometimes returned an incorrect result.
