### PR TITLE
Remove `Luhn.Compute()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Removed
 - Removed .NET 7 support
+- Removed `Luhn.Compute()` method
 
 ## [1.1.0] - 2024-03-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ namespace Example8
 
 # CLI building instructions
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
-## Using dotnet to build for .NET 6, .NET 7, .NET 8 and .NET FX 4.x
+## Using dotnet to build for .NET 6, .NET 8 and .NET FX 4.x
 Use one of the following solutions with `dotnet` to build [LuhnDotNet](#luhndotnet):
 * `LuhnDotNet.sln` (all, [see table](#build--test-status-of-default-branch))
 

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -58,15 +58,6 @@ namespace LuhnDotNet
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn check digit.</returns>
         /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid luhnNumber</exception>
-        [Obsolete("Use Luhn.CalculateCheckDigit instead", true)]
-        public static byte Compute(string number) => ComputeLuhnCheckDigit(number);
-
-        /// <summary>
-        /// Computes the Luhn check digit
-        /// </summary>
-        /// <param name="number">An identification number w/o check digit.</param>
-        /// <returns>The calculated Luhn check digit.</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid luhnNumber</exception>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
 #if NET6_0_OR_GREATER
@@ -77,7 +68,7 @@ namespace LuhnDotNet
             (byte)((Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
 
         /// <summary>
-        /// Computes the Luhn number which is a combination of the given number and the calculated check digit.
+        /// Computes the Luhn number, which is a combination of the given number and the calculated check digit.
         /// </summary>
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn number.</returns>
@@ -103,7 +94,7 @@ namespace LuhnDotNet
         }
 
         /// <summary>
-        /// Checks whether or not the Luhn Number is valid
+        /// Checks whether the Luhn Number is valid
         /// </summary>
         /// <param name="luhnNumber">An identification number w/ check digit (Luhn Number).</param>
         /// <returns><see langword="true" /> if the <paramref name="luhnNumber"/> is valid;
@@ -122,7 +113,7 @@ namespace LuhnDotNet
             luhnNumber.IsNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
 
         /// <summary>
-        /// Checks whether or not the concatenation of number and corresponding Luhn check digit is valid
+        /// Checks whether the concatenation of number and corresponding Luhn check digit is valid
         /// </summary>
         /// <param name="number">Identification number w/o check digit</param>
         /// <param name="checkDigit">The Luhn check digit</param>
@@ -230,7 +221,7 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="digits">The digits represent a number w/ or w/o check digit.</param>
         /// <param name="forValidation"><see langword="true"/> if the <paramref name="digits"/> represent
-        /// a luhnNumber including check digit; otherwise <see langword="false"/></param>
+        /// a Luhn number including a check digit; otherwise <see langword="false"/></param>
         /// <returns></returns>
         private static IEnumerable<uint> DoubleEverySecondDigit(this IEnumerable<uint> digits, bool forValidation)
         {
@@ -254,7 +245,7 @@ namespace LuhnDotNet
         }
 
         /// <summary>
-        /// Checks whether or not the <paramref name="value"/> is even.
+        /// Checks whether the <paramref name="value"/> is even.
         /// </summary>
         /// <param name="value">A numeric value of type <see cref="System.Int32"/></param>
         /// <returns><see langword="true" /> if the <paramref name="value"/> is even; otherwise
@@ -263,7 +254,7 @@ namespace LuhnDotNet
 
 #if !NET6_0_OR_GREATER
         /// <summary>
-        /// Checks whether or not the the number is valid
+        /// Checks whether the number is valid
         /// </summary>
         /// <param name="number">An identification number</param>
         /// <returns>The trimmed identification number if valid</returns>

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -181,7 +181,7 @@ namespace LuhnDotNetTest
             Assert.Equal(expectedResult, IsValid(luhnNumber));
 
         /// <summary>
-        /// Tests number validation with separate check digit.
+        /// Tests number validation with a separate check digit.
         /// </summary>
         /// <param name="expectedResult">Expected validation result</param>
         /// <param name="number">Test number exclusive check digit</param>
@@ -192,7 +192,7 @@ namespace LuhnDotNetTest
             Assert.Equal(expectedResult, IsValid(number, checkDigit));
 
         /// <summary>
-        /// Tests whether or not a exception is thrown when an invalid raw number is passed to the Luhn check
+        /// Tests whether an exception is thrown when an invalid raw number is passed to the Luhn check
         /// digit algorithm. 
         /// </summary>
         [Theory(DisplayName = "Calculates the check digit for an invalid raw number to throw an exception")]
@@ -203,7 +203,7 @@ namespace LuhnDotNetTest
         }
 
         /// <summary>
-        /// Tests whether or not a exception is thrown when an invalid raw number is passed to the Luhn
+        /// Tests whether an exception is thrown when an invalid raw number is passed to the Luhn
         /// number algorithm. 
         /// </summary>
         [Theory(DisplayName = "Calculates the Luhn number for an invalid raw number to throw an exception")]
@@ -212,7 +212,7 @@ namespace LuhnDotNetTest
             Assert.Throws<ArgumentException>(() => ComputeLuhnNumber(invalidNumber));
 
         /// <summary>
-        /// Tests whether or not a exception is thrown when an invalid Luhn number is passed to the Luhn
+        /// Tests whether an exception is thrown when an invalid Luhn number is passed to the Luhn
         /// validation algorithm.
         /// </summary>
         [Theory(DisplayName = "Validates an invalid Luhn number (e.g. none-numeric characters) to throw an exception")]
@@ -223,7 +223,7 @@ namespace LuhnDotNetTest
         }
 
         /// <summary>
-        /// Tests whether or not a exception is thrown when an invalid number and check digit between 0 and 9
+        /// Tests whether an exception is thrown when an invalid number and check digit between 0 and 9
         /// is passed to the Luhn validation algorithm.
         /// </summary>
         [Theory(DisplayName = "Validates an invalid number with any check digit between 0 and 9 to throw an exception")]
@@ -234,7 +234,7 @@ namespace LuhnDotNetTest
         }
 
         /// <summary>
-        /// Tests whether or not a exception is thrown when an invalid check digit (greater tah 9) is passed to the
+        /// Tests whether an exception is thrown when an invalid check digit (greater than 9) is passed to the
         /// Luhn validation algorithm.
         /// </summary>
         [Theory(DisplayName = "Validates a number with separate check digit greater than 9 to throw an exception")]
@@ -275,7 +275,7 @@ namespace LuhnDotNetTest
         /// </summary>
         /// <remarks>
         /// This test checks if the ConvertAlphaNumericToNumeric method throws an ArgumentException when it is given an
-        /// invalid input string that contains non-alphanumeric characters. The test uses the Assert.Throws method from
+        /// invalid input string that contains non-alphanumeric characters. The test uses the Assert. Throws method from
         /// xUnit to check if the expected exception is thrown.
         /// </remarks>
         [Fact]
@@ -317,7 +317,7 @@ namespace LuhnDotNetTest
         /// This method returns a collection of object arrays, where each array contains an input string and the
         /// expected output for the ComputeLuhnCheckDigit method. The input string is an alphanumeric string that
         /// represents a part of an ISIN without the check digit. The expected output is the check digit that makes the
-        /// entire ISIN valid according to the Luhn algorithm.
+        /// entire ISIN valid, according to the Luhn algorithm.
         /// </remarks>
         public static IEnumerable<object[]> ComputeLuhnCheckDigitWithConvertData =>
             new List<object[]>
@@ -337,7 +337,7 @@ namespace LuhnDotNetTest
         /// This test checks if the ComputeLuhnCheckDigit method returns the expected check digit when it is given an
         /// alphanumeric string that represents a part of an ISIN without the check digit. The input string is first
         /// converted to a numeric string using the ConvertAlphaNumericToNumeric method, and then the
-        /// ComputeLuhnCheckDigit method is called with this numeric string. The test uses the Assert.Equal method from
+        /// ComputeLuhnCheckDigit method is called with this numeric string. The test uses the Assert. Equal method from
         /// xUnit to check if the actual check digit matches the expected check digit.
         /// </remarks>
         [Theory]


### PR DESCRIPTION
This commit removes the obsolete `Luhn.Compute()` method from the codebase, as reflected in the CHANGELOG. Minor docstring adjustments were also made for clarity and consistency.

Resolves: No entry