### PR TITLE
Add .NET 9 support to workflows, build, and documentation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,13 +42,18 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.404
 
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4.1.0
+      with:
+        dotnet-version: 9.0.100
+
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/8.0.100}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/8.0.404/9.0.100}/* $DOTNET_ROOT/
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -19,9 +19,14 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.404
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4.1.0
+      with:
+        dotnet-version: 9.0.100
 
     - name: Restore
       run: dotnet restore LuhnDotNet.sln

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -17,9 +17,14 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.404
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4.1.0
+      with:
+        dotnet-version: 9.0.100
 
     - name: Decrypt large secret
       run: ./.github/secrets/decrypt_publisher_snk.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add [API documentation](https://sebastian-walther.de/LuhnDotNet/api/LuhnDotNet.html)
+- Add .NET 9 support
 
 ### Removed
 - Removed .NET 7 support

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The Luhn algorithm is a checksum formula used to validate identification numbers
   </thead>
   <tbody>
       <tr>
-          <td rowspan=8><a href ="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
-          <td rowspan=8><code>LuhnDotNet.sln</code></td>
-          <td rowspan=8>SDK</td>
+          <td rowspan=9><a href ="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=9><code>LuhnDotNet.sln</code></td>
+          <td rowspan=9>SDK</td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -41,6 +41,9 @@ The Luhn algorithm is a checksum formula used to validate identification numbers
       <tr>
           <td>.NET 8</td>
       </tr>
+      <tr>
+          <td>.NET 9</td>
+      </tr>
   </tbody>
 </table>
 
@@ -57,10 +60,13 @@ The Luhn algorithm is a checksum formula used to validate identification numbers
   </thead>
   <tbody>
       <tr>
-          <td rowspan=8><a href="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20NuGet/badge.svg?branch=v1.1.0" alt="LuhnDotNet NuGet"/></a></td>
-          <td rowspan=8><a href="https://badge.fury.io/nu/LuhnDotNet" target="_blank"><img src="https://badge.fury.io/nu/LuhnDotNet.svg" alt="NuGet Version 1.1.0"/></a></td>
-          <td rowspan=8><a href="https://github.com/shinji-san/LuhnDotNet/tree/v1.1.0" target="_blank"><img src="https://img.shields.io/badge/LuhnDotNet-1.1.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20NuGet/badge.svg?branch=v1.1.0" alt="LuhnDotNet NuGet"/></a></td>
+          <td rowspan=9><a href="https://badge.fury.io/nu/LuhnDotNet" target="_blank"><img src="https://badge.fury.io/nu/LuhnDotNet.svg" alt="NuGet Version 1.1.0"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/tree/v1.1.0" target="_blank"><img src="https://img.shields.io/badge/LuhnDotNet-1.1.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>.NET 8</td>
+      </tr>
+      <tr>
+          <td>.NET 9</td>
       </tr>
       <tr>
           <td>Standard 2.0</td>
@@ -300,7 +306,7 @@ namespace Example8
 
 # CLI building instructions
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
-## Using dotnet to build for .NET 8 and .NET FX 4.x
+## Using dotnet to build for .NET 8, .NET 9 and .NET FX 4.x
 Use one of the following solutions with `dotnet` to build [LuhnDotNet](#luhndotnet):
 * `LuhnDotNet.sln` (all, [see table](#build--test-status-of-default-branch))
 

--- a/src/LuhnDotNet.csproj
+++ b/src/LuhnDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net8.0;net9.0</TargetFrameworks>
         <AssemblyOriginatorKeyFile>LuhnDotNet.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>True</SignAssembly>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/LuhnDotNetTest.csproj
+++ b/tests/LuhnDotNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request includes several updates to add .NET 9 support across various files and configurations. The changes primarily involve updating workflows, documentation, and project files to accommodate the new .NET version.

Updates for .NET 9 support:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L45-R56): Added setup for .NET 9 and updated the rsync command to include .NET 9.
* [`.github/workflows/dotnetall.yml`](diffhunk://#diff-41ab2c28d621ef59806d61fb5286fc0cd88039bf56293febcdf3895606f1cd78L22-R30): Added setup for .NET 9.
* [`.github/workflows/publishing.yml`](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L20-R28): Added setup for .NET 9.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10): Added a note about .NET 9 support.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R20): Updated to include .NET 9 in the build status table and CLI building instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L303-R309)
* [`src/LuhnDotNet.csproj`](diffhunk://#diff-ac788529eec3179b1c24c66f949fdb31a276cf161638576d0abe72189e1e8090L4-R4): Added `net9.0` to the target frameworks.
* [`tests/LuhnDotNetTest.csproj`](diffhunk://#diff-26503caf427586c9f1a59e4e777727b5a102eb71e65295396e4dab1588ccdad4L4-R4): Added `net9.0` to the target frameworks.