### PR TITLE
Update GitHub Actions to use latest versions of tools

### DIFF
--- a/.github/workflows/docfx-build-and-publish.yml
+++ b/.github/workflows/docfx-build-and-publish.yml
@@ -20,11 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Dotnet Setup
-        uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: 8.0.404
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 9.0.100
 
       - run: dotnet tool update -g docfx
       - run: docfx docfx.json


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/docfx-build-and-publish.yml` file to enhance the build and publish workflow by updating the checkout and .NET setup actions.

Workflow improvements:

* Updated the `actions/checkout` action from version 3 to version 4. (`.github/workflows/docfx-build-and-publish.yml`)
* Updated the `actions/setup-dotnet` action from version 3 to version 4.1.0 and added a step to set up .NET 9. (`.github/workflows/docfx-build-and-publish.yml`)