### PR TITLE
Update GitHub Actions badge links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Luhn algorithm is a checksum formula used to validate identification numbers
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href ="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=9><a href ="https://github.com/shinji-san/LuhnDotNet/actions/workflows/dotnetall.yml" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/actions/workflows/dotnetall.yml/badge.svg?branch=main" alt="Build status"/></a></td>
           <td rowspan=9><code>LuhnDotNet.sln</code></td>
           <td rowspan=9>SDK</td>
           <td>Standard 2.0</td>
@@ -62,7 +62,7 @@ The Luhn algorithm is a checksum formula used to validate identification numbers
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/actions?query=workflow%3A%22LuhnDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/workflows/LuhnDotNet%20NuGet/badge.svg?branch=v1.3.0" alt="LuhnDotNet NuGet"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/LuhnDotNet/actions/workflows/publishing.yml/badge.svg" alt="LuhnDotNet - NuGet Publishing"/></a></td>
           <td rowspan=9><a href="https://badge.fury.io/nu/LuhnDotNet" target="_blank"><img src="https://badge.fury.io/nu/LuhnDotNet.svg" alt="NuGet Version 1.3.0"/></a></td>
           <td rowspan=9><a href="https://github.com/shinji-san/LuhnDotNet/tree/v1.3.0" target="_blank"><img src="https://img.shields.io/badge/LuhnDotNet-1.3.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>.NET 8</td>


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to change the URLs of the build status and NuGet publishing badges.

Changes to badge URLs:

* Updated the build status badge URL to point to the new workflow file `dotnetall.yml` and added the branch parameter to the image source. (`README.md`, [README.mdL20-R20](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20))
* Updated the NuGet publishing badge URL to point to the new workflow file `publishing.yml` and updated the image alt text for clarity. (`README.md`, [README.mdL65-R65](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65))