### PR TITLE
Remove obsolete IsValid methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Removed `Luhn.IsValid` methods
+
 ## [1.3.0] - 2024-12-27
 ### Added
 - Add project icon

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -135,39 +135,9 @@ namespace LuhnDotNet
         /// (on the right side).</remarks>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
-        [Obsolete("Use the IsValidLuhnNumber method instead.", false)]
-        public static bool IsValid(this ReadOnlySpan<char> luhnNumber) => luhnNumber.IsValidLuhnNumber();
-
-        /// <summary>
-        /// Checks whether the Luhn Number is valid
-        /// </summary>
-        /// <param name="luhnNumber">An identification number w/ check digit (Luhn Number).</param>
-        /// <returns><see langword="true" /> if the <paramref name="luhnNumber"/> is valid;
-        /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="luhnNumber"/> is not valid.
-        /// It contains none-numeric characters.</exception>
-        /// <remarks>The check digit must be at the end of the <paramref name="luhnNumber"/>
-        /// (on the right side).</remarks>
-        [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
         public static bool IsValidLuhnNumber(this ReadOnlySpan<char> luhnNumber) =>
             luhnNumber.IsNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
 #endif
-
-        /// <summary>
-        /// Checks whether the Luhn Number is valid
-        /// </summary>
-        /// <param name="luhnNumber">An identification number w/ check digit (Luhn Number).</param>
-        /// <returns><see langword="true" /> if the <paramref name="luhnNumber"/> is valid;
-        /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="luhnNumber"/> is not valid.
-        /// It contains none-numeric characters.</exception>
-        /// <remarks>The check digit must be at the end of the <paramref name="luhnNumber"/>
-        /// (on the right side).</remarks>
-        [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
-        [Obsolete("Use the IsValidLuhnNumber method instead.", false)]
-        public static bool IsValid(this string luhnNumber) => luhnNumber.IsValidLuhnNumber();
 
         /// <summary>
         /// Checks whether the Luhn Number is valid
@@ -189,23 +159,6 @@ namespace LuhnDotNet
 #endif
 
 #if NET8_0_OR_GREATER
-        /// <summary>
-        /// Checks whether the concatenation of number and corresponding Luhn check digit is valid
-        /// </summary>
-        /// <param name="number">Identification number w/o Luhn check digit</param>
-        /// <param name="checkDigit">The Luhn check digit</param>
-        /// <returns><see langword="true" /> if the <paramref name="number"/> is valid;
-        /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
-        /// It contains none-numeric characters.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkDigit"/> value is greater than 9.
-        /// The <paramref name="checkDigit"/> value must be between 0 and 9.</exception>
-        [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
-        [Obsolete("Use the IsValidLuhnCheckDigit method instead.", false)]
-        public static bool IsValid(this ReadOnlySpan<char> number, byte checkDigit) =>
-            checkDigit.IsValidLuhnCheckDigit(number);
-
         /// <summary>
         /// Checks whether the concatenation of number and corresponding Luhn check digit is valid
         /// </summary>
@@ -237,22 +190,6 @@ namespace LuhnDotNet
                 .SumDigits() == 0;
         }
 #endif
-
-        /// <summary>
-        /// Checks whether the concatenation of number and corresponding Luhn check digit is valid
-        /// </summary>
-        /// <param name="number">Identification number w/o Luhn check digit</param>
-        /// <param name="checkDigit">The Luhn check digit</param>
-        /// <returns><see langword="true" /> if the <paramref name="number"/> is valid;
-        /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
-        /// It contains none-numeric characters.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkDigit"/> value is greater than 9.
-        /// The <paramref name="checkDigit"/> value must be between 0 and 9.</exception>
-        [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
-        [Obsolete("Use the IsValidLuhnCheckDigit method instead.", false)]
-        public static bool IsValid(this string number, byte checkDigit) => checkDigit.IsValidLuhnCheckDigit(number);
 
         /// <summary>
         /// Checks whether the concatenation of number and corresponding Luhn check digit is valid

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -52,6 +52,11 @@ namespace LuhnDotNet
         /// </summary>
         private const int Modulus = 10;
 
+        /// <summary>
+        /// Represents the ASCII code for the character '0'.
+        /// </summary>
+        private const int AsciiCodeForZero = 48;
+
 #if NET8_0_OR_GREATER
         /// <summary>
         /// Computes the Luhn check digit
@@ -63,7 +68,7 @@ namespace LuhnDotNet
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
         public static byte ComputeLuhnCheckDigit(this ReadOnlySpan<char> number) =>
-            (byte)((Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
+            (byte)((Modulus - number.ValidateAndTrimNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
 #endif
 
         /// <summary>
@@ -79,7 +84,7 @@ namespace LuhnDotNet
 #if NET8_0_OR_GREATER
             number.AsSpan().ComputeLuhnCheckDigit();
 #else
-            (byte)((Modulus - number.IsNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
+            (byte)((Modulus - number.ValidateAndTrimNumber().GetDigits().DoubleEverySecondDigit(false).SumDigits()) % Modulus);
 #endif
 
 #if NET8_0_OR_GREATER
@@ -136,7 +141,7 @@ namespace LuhnDotNet
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
         public static bool IsValidLuhnNumber(this ReadOnlySpan<char> luhnNumber) =>
-            luhnNumber.IsNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
+            luhnNumber.ValidateAndTrimNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
 #endif
 
         /// <summary>
@@ -155,7 +160,7 @@ namespace LuhnDotNet
 #if NET8_0_OR_GREATER
             luhnNumber.AsSpan().IsValidLuhnNumber();
 #else
-            luhnNumber.IsNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
+            luhnNumber.ValidateAndTrimNumber().GetDigits().DoubleEverySecondDigit(true).SumDigits() == 0;
 #endif
 
 #if NET8_0_OR_GREATER
@@ -184,7 +189,7 @@ namespace LuhnDotNet
 
             return string.Concat(number.Trim(), checkDigit.ToString(CultureInfo.InvariantCulture))
                 .AsSpan()
-                .IsNumber()
+                .ValidateAndTrimNumber()
                 .GetDigits()
                 .DoubleEverySecondDigit(true)
                 .SumDigits() == 0;
@@ -222,7 +227,7 @@ namespace LuhnDotNet
                     "{0}{1}",
                     number.Trim(),
                     checkDigit.ToString(CultureInfo.InvariantCulture))
-                .IsNumber()
+                .ValidateAndTrimNumber()
                 .GetDigits()
                 .DoubleEverySecondDigit(true)
                 .SumDigits() == 0;
@@ -294,12 +299,12 @@ namespace LuhnDotNet
 #endif
 
         /// <summary>
-        /// Doubling of every second digit.
+        /// Doubles every second digit of the <paramref name="digits"/> enumeration.
         /// </summary>
         /// <param name="digits">The digits represent a number w/ or w/o check digit.</param>
         /// <param name="forValidation"><see langword="true"/> if the <paramref name="digits"/> represent
         /// a Luhn number including a check digit; otherwise <see langword="false"/></param>
-        /// <returns></returns>
+        /// <returns>Enumeration of digits</returns>
         private static IEnumerable<uint> DoubleEverySecondDigit(this IEnumerable<uint> digits, bool forValidation)
         {
             int index = 0;
@@ -336,7 +341,7 @@ namespace LuhnDotNet
         /// <param name="number">An identification number</param>
         /// <returns>The trimmed identification number if valid</returns>
         /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid number</exception>
-        private static string IsNumber(this string number)
+        private static string ValidateAndTrimNumber(this string number)
         {
             string trimmedNumber = number?.Trim();
             if (string.IsNullOrWhiteSpace(trimmedNumber) || !Regex.IsMatch(trimmedNumber, @"^\d+$"))
@@ -355,7 +360,7 @@ namespace LuhnDotNet
         /// <param name="number">An identification number</param>
         /// <returns>The trimmed identification number if valid</returns>
         /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid number</exception>
-        private static ReadOnlySpan<char> IsNumber(this ReadOnlySpan<char> number)
+        private static ReadOnlySpan<char> ValidateAndTrimNumber(this ReadOnlySpan<char> number)
         {
             var trimmedNumber = number.Trim();
             if (trimmedNumber.Length == 0 || !trimmedNumber.IsDigits())
@@ -397,7 +402,7 @@ namespace LuhnDotNet
             uint[] digits = new uint[number.Length];
             for (int i = 0; i < number.Length; i++)
             {
-                digits[number.Length - i - 1] = (uint)number[i] - 48;
+                digits[number.Length - i - 1] = (uint)number[i] - AsciiCodeForZero;
             }
 
             return digits;
@@ -407,7 +412,7 @@ namespace LuhnDotNet
         {
             for (int i = number.Length - 1; i >= 0; i--)
             {
-                yield return (uint)number[i] - 48;
+                yield return (uint)number[i] - AsciiCodeForZero;
             }
         }
 #endif

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -187,9 +187,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(LuhnNumberValidationSet), MemberType = typeof(LuhnTest))]
         public void LuhnNumberValidationTest(bool expectedResult, string luhnNumber)
         {
-            Assert.Equal(expectedResult, luhnNumber.IsValid());
             Assert.Equal(expectedResult, luhnNumber.IsValidLuhnNumber());
-            Assert.Equal(expectedResult, luhnNumber.AsSpan().IsValid());
             Assert.Equal(expectedResult, luhnNumber.AsSpan().IsValidLuhnNumber());
         }
 
@@ -203,9 +201,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(LuhnCheckDigitValidationSet), MemberType = typeof(LuhnTest))]
         public void LuhnCheckDigitValidationTest(bool expectedResult, string number, byte checkDigit)
         {
-            Assert.Equal(expectedResult, number.IsValid(checkDigit));
             Assert.Equal(expectedResult, checkDigit.IsValidLuhnCheckDigit(number));
-            Assert.Equal(expectedResult, number.AsSpan().IsValid(checkDigit));
             Assert.Equal(expectedResult, checkDigit.IsValidLuhnCheckDigit(number.AsSpan()));
         }
 
@@ -243,9 +239,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
         public void LuhnNumberValidationExceptionTest(string invalidNumber)
         {
-            Assert.Throws<ArgumentException>(() => invalidNumber.IsValid());
             Assert.Throws<ArgumentException>(() => invalidNumber.IsValidLuhnNumber());
-            Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().IsValid());
             Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().IsValidLuhnNumber());
         }
 
@@ -257,9 +251,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(InvalidNumbersAndCheckDigits), MemberType = typeof(LuhnTest))]
         public void NumberValidationExceptionTest(string invalidNumber, byte checkDigit)
         {
-            Assert.Throws<ArgumentException>(() => invalidNumber.IsValid(checkDigit));
             Assert.Throws<ArgumentException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber));
-            Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().IsValid(checkDigit));
             Assert.Throws<ArgumentException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber.AsSpan()));
         }
 
@@ -271,9 +263,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(NumbersWithInvalidCheckDigits), MemberType = typeof(LuhnTest))]
         public void LuhnCheckDigitValidationExceptionTest(string invalidNumber, byte checkDigit)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => invalidNumber.IsValid(checkDigit));
             Assert.Throws<ArgumentOutOfRangeException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber));
-            Assert.Throws<ArgumentOutOfRangeException>(() => invalidNumber.AsSpan().IsValid(checkDigit));
             Assert.Throws<ArgumentOutOfRangeException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber.AsSpan()));
         }
 
@@ -340,9 +330,7 @@ namespace LuhnDotNetTest
         [MemberData(nameof(IsValidWithConvertData), MemberType = typeof(LuhnTest))]
         public void IsValidWithConvertTest(string input, bool expected)
         {
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().IsValid());
             Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().IsValidLuhnNumber());
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().AsSpan().IsValid());
             Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().AsSpan().IsValidLuhnNumber());
         }
 


### PR DESCRIPTION
This pull request includes several changes to the `Luhn` class and its associated tests. The most significant changes involve the removal of obsolete `IsValid` methods and the introduction of the `ValidateAndTrimNumber` method for better validation. Additionally, the `AsciiCodeForZero` constant has been added for improved code readability.

### Changes to `Luhn` class:

* Removed obsolete `IsValid` methods and replaced their usage with `IsValidLuhnNumber` and `IsValidLuhnCheckDigit` methods. [[1]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL126-L140) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL154-L171) [[3]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL188-L208) [[4]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL234-L256) [[5]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL288-R230)
* Introduced the `ValidateAndTrimNumber` method to replace `IsNumber` for better validation and trimming of input numbers. [[1]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL402-R344) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL421-R363)
* Added `AsciiCodeForZero` constant to improve code readability in digit extraction methods. [[1]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bR55-R59) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL463-R405) [[3]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL473-R415)
* Updated `ComputeLuhnCheckDigit` and `IsValidLuhnNumber` methods to use `ValidateAndTrimNumber` for input validation. [[1]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL66-R71) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL82-R87) [[3]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL154-L171) [[4]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL188-L208)

### Changes to tests:

* Removed references to obsolete `IsValid` methods in test cases and replaced them with `IsValidLuhnNumber` and `IsValidLuhnCheckDigit` methods. [[1]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL190-L192) [[2]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL206-L208) [[3]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL246-L248) [[4]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL260-L262) [[5]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL274-L276) [[6]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL343-L345)

### Documentation:

* Updated `CHANGELOG.md` to reflect the removal of `Luhn.IsValid` methods.