### PR TITLE
Rename ConvertAlphaNumericToNumeric to AlphaNumericToNumeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Renamed `Luhn.ConvertAlphaNumericToNumeric` to `Luhn.AlphaNumericToNumeric`
+
 ### Removed
 - Removed `Luhn.IsValid` methods
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ namespace Example4
 }
 ```
 
-## Validate ISIN with LuhnDotNet and ConvertAlphaNumericToNumeric
+## Validate ISIN with LuhnDotNet and AlphaNumericToNumeric
 
-The `LuhnDotNet` library can be used in combination with the `ConvertAlphaNumericToNumeric` method to validate an International Securities Identification Number (ISIN). An ISIN uniquely identifies a security, such as stocks, bonds or derivatives. It is a 12-character alphanumeric code.
+The `LuhnDotNet` library can be used in combination with the `AlphaNumericToNumeric` method to validate an International Securities Identification Number (ISIN). An ISIN uniquely identifies a security, such as stocks, bonds or derivatives. It is a 12-character alphanumeric code.
 
-The `ConvertAlphaNumericToNumeric` method is used to convert the alphanumeric ISIN to a numeric string, where each letter in the input string is replaced by its decimal ASCII value minus 55. This numeric string can then be validated using the `Luhn.IsValid` method.
+The `AlphaNumericToNumeric` method is used to convert the alphanumeric ISIN to a numeric string, where each letter in the input string is replaced by its decimal ASCII value minus 55. This numeric string can then be validated using the `Luhn.IsValid` method.
 
 Here is an example of how to use these methods to validate an ISIN:
 
@@ -231,15 +231,15 @@ namespace Example5
         public static void Main(string[] args)
         {
             string isin = "US0378331005";
-            bool isValid = isin.ConvertAlphaNumericToNumeric().IsValidLuhnNumber();
+            bool isValid = isin.AlphaNumericToNumeric().IsValidLuhnNumber();
             Console.WriteLine($"The ISIN {isin} is valid: {isValid}");
         }
     }
 }
 ```
-## Compute ISIN Check Digit with LuhnDotNet and ConvertAlphaNumericToNumeric
+## Compute ISIN Check Digit with LuhnDotNet and AlphaNumericToNumeric
 
-The `LuhnDotNet` library provides the `ComputeLuhnCheckDigit` method which can be used to compute the check digit of a numeric string according to the Luhn algorithm. When dealing with an International Securities Identification Number (ISIN), which is a 12-character alphanumeric code, we first need to convert the alphanumeric ISIN to a numeric string. This can be achieved using the `ConvertAlphaNumericToNumeric` method.
+The `LuhnDotNet` library provides the `ComputeLuhnCheckDigit` method which can be used to compute the check digit of a numeric string according to the Luhn algorithm. When dealing with an International Securities Identification Number (ISIN), which is a 12-character alphanumeric code, we first need to convert the alphanumeric ISIN to a numeric string. This can be achieved using the `AlphaNumericToNumeric` method.
 
 Here is an example of how to compute the check digit of an ISIN:
 
@@ -254,7 +254,7 @@ namespace Example6
         public static void Main(string[] args)
         {
             string isinWithoutCheckDigit = "US037833100";
-            byte checkDigit = isinWithoutCheckDigit.ConvertAlphaNumericToNumeric().ComputeLuhnCheckDigit();
+            byte checkDigit = isinWithoutCheckDigit.AlphaNumericToNumeric().ComputeLuhnCheckDigit();
             Console.WriteLine($"The check digit for ISIN {isinWithoutCheckDigit} is: {checkDigit}");
         }
     }

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -246,7 +246,7 @@ namespace LuhnDotNet
         /// This method iterates over each character in the input string. If the character is a letter, it is replaced
         /// by its decimal ASCII value minus 55. If the character is a digit, it is left unchanged.
         /// </remarks>
-        public static string ConvertAlphaNumericToNumeric(this string alphaNumeric)
+        public static string AlphaNumericToNumeric(this string alphaNumeric)
 #if NET8_0_OR_GREATER
         {
             Span<char> result = stackalloc char[alphaNumeric.Length * 2];

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -268,7 +268,7 @@ namespace LuhnDotNetTest
         }
 
         /// <summary>
-        /// Test data for ConvertAlphaNumericToNumeric method.
+        /// Test data for AlphaNumericToNumeric method.
         /// </summary>
         public static IEnumerable<object[]> ConvertAlphaNumericToNumericData =>
             new List<object[]>
@@ -282,7 +282,7 @@ namespace LuhnDotNetTest
             };
 
         /// <summary>
-        /// Tests the ConvertAlphaNumericToNumeric method.
+        /// Tests the AlphaNumericToNumeric method.
         /// </summary>
         /// <param name="input">Input string</param>
         /// <param name="expected">Expected output</param>
@@ -290,25 +290,25 @@ namespace LuhnDotNetTest
         [MemberData(nameof(ConvertAlphaNumericToNumericData), MemberType = typeof(LuhnTest))]
         public void ConvertAlphaNumericToNumeric_ShouldReturnExpectedResult(string input, string expected)
         {
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric());
+            Assert.Equal(expected, input.AlphaNumericToNumeric());
         }
 
         /// <summary>
-        /// Tests the ConvertAlphaNumericToNumeric method with invalid input.
+        /// Tests the AlphaNumericToNumeric method with invalid input.
         /// </summary>
         /// <remarks>
-        /// This test checks if the ConvertAlphaNumericToNumeric method throws an ArgumentException when it is given an
+        /// This test checks if the AlphaNumericToNumeric method throws an ArgumentException when it is given an
         /// invalid input string that contains non-alphanumeric characters. The test uses the Assert. Throws method from
         /// xUnit to check if the expected exception is thrown.
         /// </remarks>
         [Fact(DisplayName = "Converts an invalid alphanumeric string to a numeric string to throw an exception")]
         public void ConvertAlphaNumericToNumeric_InvalidInput_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(()=> "!@#$%^&*()".ConvertAlphaNumericToNumeric());
+            Assert.Throws<ArgumentException>(()=> "!@#$%^&*()".AlphaNumericToNumeric());
         }
 
         /// <summary>
-        /// Test data for IsValid method in combination with ConvertAlphaNumericToNumeric.
+        /// Test data for IsValid method in combination with AlphaNumericToNumeric.
         /// </summary>
         public static IEnumerable<object[]> IsValidWithConvertData =>
             new List<object[]>
@@ -322,7 +322,7 @@ namespace LuhnDotNetTest
             };
 
         /// <summary>
-        /// Tests the IsValid method in combination with ConvertAlphaNumericToNumeric.
+        /// Tests the IsValid method in combination with AlphaNumericToNumeric.
         /// </summary>
         /// <param name="input">Input string</param>
         /// <param name="expected">Expected output</param>
@@ -330,12 +330,12 @@ namespace LuhnDotNetTest
         [MemberData(nameof(IsValidWithConvertData), MemberType = typeof(LuhnTest))]
         public void IsValidWithConvertTest(string input, bool expected)
         {
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().IsValidLuhnNumber());
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().AsSpan().IsValidLuhnNumber());
+            Assert.Equal(expected, input.AlphaNumericToNumeric().IsValidLuhnNumber());
+            Assert.Equal(expected, input.AlphaNumericToNumeric().AsSpan().IsValidLuhnNumber());
         }
 
         /// <summary>
-        /// Provides test data for the ComputeLuhnCheckDigit method in combination with ConvertAlphaNumericToNumeric.
+        /// Provides test data for the ComputeLuhnCheckDigit method in combination with AlphaNumericToNumeric.
         /// </summary>
         /// <remarks>
         /// This method returns a collection of object arrays, where each array contains an input string and the
@@ -353,14 +353,14 @@ namespace LuhnDotNetTest
             };
 
         /// <summary>
-        /// Tests the ComputeLuhnCheckDigit method in combination with ConvertAlphaNumericToNumeric.
+        /// Tests the ComputeLuhnCheckDigit method in combination with AlphaNumericToNumeric.
         /// </summary>
         /// <param name="input">Input string</param>
         /// <param name="expected">Expected output</param>
         /// <remarks>
         /// This test checks if the ComputeLuhnCheckDigit method returns the expected check digit when it is given an
         /// alphanumeric string that represents a part of an ISIN without the check digit. The input string is first
-        /// converted to a numeric string using the ConvertAlphaNumericToNumeric method, and then the
+        /// converted to a numeric string using the AlphaNumericToNumeric method, and then the
         /// ComputeLuhnCheckDigit method is called with this numeric string. The test uses the Assert. Equal method from
         /// xUnit to check if the actual check digit matches the expected check digit.
         /// </remarks>
@@ -370,8 +370,8 @@ namespace LuhnDotNetTest
             string input,
             byte expected)
         {
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().ComputeLuhnCheckDigit());
-            Assert.Equal(expected, input.ConvertAlphaNumericToNumeric().AsSpan().ComputeLuhnCheckDigit());
+            Assert.Equal(expected, input.AlphaNumericToNumeric().ComputeLuhnCheckDigit());
+            Assert.Equal(expected, input.AlphaNumericToNumeric().AsSpan().ComputeLuhnCheckDigit());
         }
     }
 }


### PR DESCRIPTION

This pull request focuses on renaming the method `ConvertAlphaNumericToNumeric` to `AlphaNumericToNumeric` across the codebase for consistency and clarity. The changes span multiple files, including documentation, source code, and test cases.

### Method Renaming:

* [`src/Luhn.cs`](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL249-R249): Renamed method `ConvertAlphaNumericToNumeric` to `AlphaNumericToNumeric`.

### Documentation Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R10): Updated to reflect the renaming of `Luhn.ConvertAlphaNumericToNumeric` to `Luhn.AlphaNumericToNumeric`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L215-R219): Updated references to `ConvertAlphaNumericToNumeric` method to `AlphaNumericToNumeric` in multiple sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L215-R219) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L234-R242) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L257-R257)

### Test Updates:

* [`tests/LuhnTest.cs`](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL271-R271): Updated test method names and references from `ConvertAlphaNumericToNumeric` to `AlphaNumericToNumeric`. [[1]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL271-R271) [[2]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL285-R311) [[3]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL325-R338) [[4]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL356-R363) [[5]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL373-R374)