### PR TITLE
Refactor exceptions to use `InvalidCharacterException`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `InvalidCharacterException` to throw an exception if the input string contains invalid characters.
+
 ### Changed
 - Renamed `Luhn.ConvertAlphaNumericToNumeric` to `Luhn.AlphaNumericToNumeric`
 

--- a/src/InvalidCharacterException.cs
+++ b/src/InvalidCharacterException.cs
@@ -1,0 +1,94 @@
+// ----------------------------------------------------------------------------
+// <copyright file="InvalidCharacterException.cs" company="Private">
+// Copyright (c) 2025 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>01/01/2025 09:00:26 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2025 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+using System;
+using System.Runtime.Serialization;
+
+namespace LuhnDotNet
+{
+    /// <summary>
+    /// The exception that is thrown when an invalid character is encountered within an argument.
+    /// </summary>
+    [Serializable]
+    public class InvalidCharacterException : ArgumentException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidCharacterException"/> class.
+        /// </summary>
+        public InvalidCharacterException() : base("Invalid character encountered in argument.")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidCharacterException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public InvalidCharacterException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidCharacterException"/> class with a specified error message
+        /// and the name of the parameter that caused this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="paramName">The name of the parameter that caused the current exception.</param>
+        public InvalidCharacterException(string message, string paramName) : base(message, paramName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidCharacterException"/> class with a specified error message,
+        /// the parameter name, and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="paramName">The name of the parameter that caused the current exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception
+        /// or a null reference if no inner exception is specified.</param>
+        public InvalidCharacterException(string message, string paramName, Exception innerException) : base(message, paramName, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidCharacterException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete(
+            "This constructor is obsolete and will be removed in a future version. Use InvalidCharacterException(string message, string paramName, Exception innerException) instead.",
+            false)]
+        protected InvalidCharacterException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -63,7 +63,7 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn check digit.</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
@@ -76,7 +76,7 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn check digit as a byte.</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
@@ -93,7 +93,7 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn number.</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
@@ -109,7 +109,7 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number w/o check digit.</param>
         /// <returns>The calculated Luhn number.</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         [SuppressMessage("ReSharper", "HeapView.ObjectAllocation")]
@@ -134,7 +134,7 @@ namespace LuhnDotNet
         /// <param name="luhnNumber">An identification number w/ check digit (Luhn Number).</param>
         /// <returns><see langword="true" /> if the <paramref name="luhnNumber"/> is valid;
         /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="luhnNumber"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="luhnNumber"/> is not valid.
         /// It contains none-numeric characters.</exception>
         /// <remarks>The check digit must be at the end of the <paramref name="luhnNumber"/>
         /// (on the right side).</remarks>
@@ -150,7 +150,7 @@ namespace LuhnDotNet
         /// <param name="luhnNumber">An identification number w/ check digit (Luhn Number).</param>
         /// <returns><see langword="true" /> if the <paramref name="luhnNumber"/> is valid;
         /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="luhnNumber"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="luhnNumber"/> is not valid.
         /// It contains none-numeric characters.</exception>
         /// <remarks>The check digit must be at the end of the <paramref name="luhnNumber"/>
         /// (on the right side).</remarks>
@@ -171,7 +171,7 @@ namespace LuhnDotNet
         /// <param name="number">Identification number w/o Luhn check digit</param>
         /// <returns><see langword="true" /> if the <paramref name="number"/> is valid;
         /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkDigit"/> value is greater than 9.
         /// The <paramref name="checkDigit"/> value must be between 0 and 9.</exception>
@@ -203,7 +203,7 @@ namespace LuhnDotNet
         /// <param name="number">Identification number w/o Luhn check digit</param>
         /// <returns><see langword="true" /> if the <paramref name="number"/> is valid;
         /// otherwise <see langword="false" /></returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not valid.
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not valid.
         /// It contains none-numeric characters.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkDigit"/> value is greater than 9.
         /// The <paramref name="checkDigit"/> value must be between 0 and 9.</exception>
@@ -240,7 +240,7 @@ namespace LuhnDotNet
         /// <param name="alphaNumeric">The alphanumeric string to convert.</param>
         /// <returns>A numeric string where each letter in the input string is replaced by its decimal ASCII value
         /// minus 55.</returns>
-        /// <exception cref="ArgumentException">The <paramref name="alphaNumeric"/> contains a character
+        /// <exception cref="InvalidCharacterException">The <paramref name="alphaNumeric"/> contains a character
         /// that is neither a letter nor a digit.</exception>
         /// <remarks>
         /// This method iterates over each character in the input string. If the character is a letter, it is replaced
@@ -268,7 +268,7 @@ namespace LuhnDotNet
                 }
                 else
                 {
-                    throw new ArgumentException($"The character '{c}' is not a letter or a digit!", nameof(alphaNumeric));
+                    throw new InvalidCharacterException($"The character '{c}' is not a letter or a digit!", nameof(alphaNumeric));
                 }
             }
 
@@ -290,7 +290,7 @@ namespace LuhnDotNet
                 }
                 else
                 {
-                    throw new ArgumentException($"The character '{c}' is not a letter or a digit!", nameof(alphaNumeric));
+                    throw new InvalidCharacterException($"The character '{c}' is not a letter or a digit!", nameof(alphaNumeric));
                 }
             }
 
@@ -340,13 +340,13 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number</param>
         /// <returns>The trimmed identification number if valid</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid number</exception>
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not a valid number</exception>
         private static string ValidateAndTrimNumber(this string number)
         {
             string trimmedNumber = number?.Trim();
             if (string.IsNullOrWhiteSpace(trimmedNumber) || !Regex.IsMatch(trimmedNumber, @"^\d+$"))
             {
-                throw new ArgumentException($"The string '{number}' is not a number!", nameof(number));
+                throw new InvalidCharacterException($"The string '{number}' is not a number!", nameof(number));
             }
 
             return trimmedNumber;
@@ -359,13 +359,13 @@ namespace LuhnDotNet
         /// </summary>
         /// <param name="number">An identification number</param>
         /// <returns>The trimmed identification number if valid</returns>
-        /// <exception cref="ArgumentException"><paramref name="number"/> is not a valid number</exception>
+        /// <exception cref="InvalidCharacterException"><paramref name="number"/> is not a valid number</exception>
         private static ReadOnlySpan<char> ValidateAndTrimNumber(this ReadOnlySpan<char> number)
         {
             var trimmedNumber = number.Trim();
             if (trimmedNumber.Length == 0 || !trimmedNumber.IsDigits())
             {
-                throw new ArgumentException($"The string '{number}' is not a number!", nameof(number));
+                throw new InvalidCharacterException($"The string '{number}' is not a number!", nameof(number));
             }
 
             return trimmedNumber;

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -183,9 +183,9 @@ namespace LuhnDotNetTest
         /// </summary>
         /// <param name="expectedResult">The expected validation result</param>
         /// <param name="luhnNumber">Test number inclusive check digit</param>
-        [Theory(DisplayName = "Validates a number containing a check digit")]
+        [Theory(DisplayName = "Validates a valid Luhn number")]
         [MemberData(nameof(LuhnNumberValidationSet), MemberType = typeof(LuhnTest))]
-        public void LuhnNumberValidationTest(bool expectedResult, string luhnNumber)
+        public void IsValidLuhnNumber_ValidLuhnNumber_ReturnsExpectedResult(bool expectedResult, string luhnNumber)
         {
             Assert.Equal(expectedResult, luhnNumber.IsValidLuhnNumber());
             Assert.Equal(expectedResult, luhnNumber.AsSpan().IsValidLuhnNumber());
@@ -197,9 +197,12 @@ namespace LuhnDotNetTest
         /// <param name="expectedResult">Expected validation result</param>
         /// <param name="number">Test number exclusive check digit</param>
         /// <param name="checkDigit">Test Luhn check digit</param>
-        [Theory(DisplayName = "Validates a number with separate check digit between 0 and 9")]
+        [Theory(DisplayName = "Validates a valid number with separate, valid check digit between 0 and 9")]
         [MemberData(nameof(LuhnCheckDigitValidationSet), MemberType = typeof(LuhnTest))]
-        public void LuhnCheckDigitValidationTest(bool expectedResult, string number, byte checkDigit)
+        public void IsValidLuhnCheckDigit_ValidNumberAndCheckDigit_ReturnsExpectedResult(
+            bool expectedResult,
+            string number,
+            byte checkDigit)
         {
             Assert.Equal(expectedResult, checkDigit.IsValidLuhnCheckDigit(number));
             Assert.Equal(expectedResult, checkDigit.IsValidLuhnCheckDigit(number.AsSpan()));
@@ -212,10 +215,10 @@ namespace LuhnDotNetTest
         /// <param name="invalidNumber">Invalid raw number</param>
         [Theory(DisplayName = "Calculates the check digit for an invalid raw number to throw an exception")]
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
-        public void ComputeLuhnCheckDigit_InvalidRawNumber_ThrowsArgumentException(string invalidNumber)
+        public void ComputeLuhnCheckDigit_InvalidRawNumber_ThrowsInvalidCharacterException(string invalidNumber)
         {
-            Assert.Throws<ArgumentException>(() => invalidNumber.ComputeLuhnCheckDigit());
-            Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().ComputeLuhnCheckDigit());
+            Assert.Throws<InvalidCharacterException>(() => invalidNumber.ComputeLuhnCheckDigit());
+            Assert.Throws<InvalidCharacterException>(() => invalidNumber.AsSpan().ComputeLuhnCheckDigit());
         }
 
         /// <summary>
@@ -225,10 +228,10 @@ namespace LuhnDotNetTest
         /// <param name="invalidNumber">Invalid raw number</param>
         [Theory(DisplayName = "Calculates the Luhn number for an invalid raw number to throw an exception")]
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
-        public void ComputeLuhnNumber_InvalidRawNumber_ThrowsArgumentException(string invalidNumber)
+        public void ComputeLuhnNumber_InvalidRawNumber_ThrowsInvalidCharacterException(string invalidNumber)
         {
-            Assert.Throws<ArgumentException>(invalidNumber.ComputeLuhnNumber);
-            Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().ComputeLuhnNumber());
+            Assert.Throws<InvalidCharacterException>(invalidNumber.ComputeLuhnNumber);
+            Assert.Throws<InvalidCharacterException>(() => invalidNumber.AsSpan().ComputeLuhnNumber());
         }
 
         /// <summary>
@@ -237,22 +240,23 @@ namespace LuhnDotNetTest
         /// </summary>
         [Theory(DisplayName = "Validates an invalid Luhn number (e.g. none-numeric characters) to throw an exception")]
         [MemberData(nameof(InvalidNumbers), MemberType = typeof(LuhnTest))]
-        public void LuhnNumberValidationExceptionTest(string invalidNumber)
+        public void IsValidLuhnNumber_InvalidInput_ThrowsInvalidCharacterException(string invalidNumber)
         {
-            Assert.Throws<ArgumentException>(() => invalidNumber.IsValidLuhnNumber());
-            Assert.Throws<ArgumentException>(() => invalidNumber.AsSpan().IsValidLuhnNumber());
+            Assert.Throws<InvalidCharacterException>(() => invalidNumber.IsValidLuhnNumber());
+            Assert.Throws<InvalidCharacterException>(() => invalidNumber.AsSpan().IsValidLuhnNumber());
         }
 
         /// <summary>
-        /// Tests whether an exception is thrown when an invalid number and a valid check digit between 0 and 9
-        /// is passed to the Luhn validation algorithm.
+        /// Tests whether an exception is thrown when an invalid number is passed to the Luhn validation algorithm.
         /// </summary>
         [Theory(DisplayName = "Validates an invalid number with any check digit between 0 and 9 to throw an exception")]
         [MemberData(nameof(InvalidNumbersAndCheckDigits), MemberType = typeof(LuhnTest))]
-        public void NumberValidationExceptionTest(string invalidNumber, byte checkDigit)
+        public void IsValidLuhnCheckDigit_InvalidInput_ThrowsInvalidCharacterException(
+            string invalidNumber,
+            byte checkDigit)
         {
-            Assert.Throws<ArgumentException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber));
-            Assert.Throws<ArgumentException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber.AsSpan()));
+            Assert.Throws<InvalidCharacterException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber));
+            Assert.Throws<InvalidCharacterException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber.AsSpan()));
         }
 
         /// <summary>
@@ -261,7 +265,9 @@ namespace LuhnDotNetTest
         /// </summary>
         [Theory(DisplayName = "Validates a number with separate check digit greater than 9 to throw an exception")]
         [MemberData(nameof(NumbersWithInvalidCheckDigits), MemberType = typeof(LuhnTest))]
-        public void LuhnCheckDigitValidationExceptionTest(string invalidNumber, byte checkDigit)
+        public void IsValidLuhnCheckDigit_InvalidInput_ThrowsArgumentOutOfRangeException(
+            string invalidNumber,
+            byte checkDigit)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber));
             Assert.Throws<ArgumentOutOfRangeException>(() => checkDigit.IsValidLuhnCheckDigit(invalidNumber.AsSpan()));
@@ -270,7 +276,7 @@ namespace LuhnDotNetTest
         /// <summary>
         /// Test data for AlphaNumericToNumeric method.
         /// </summary>
-        public static IEnumerable<object[]> ConvertAlphaNumericToNumericData =>
+        public static IEnumerable<object[]> AlphaNumericToNumericData =>
             new List<object[]>
             {
                 new object[] { "A1B2C3", "101112123" },
@@ -287,8 +293,8 @@ namespace LuhnDotNetTest
         /// <param name="input">Input string</param>
         /// <param name="expected">Expected output</param>
         [Theory(DisplayName = "Converts an alphanumeric string to a numeric string")]
-        [MemberData(nameof(ConvertAlphaNumericToNumericData), MemberType = typeof(LuhnTest))]
-        public void ConvertAlphaNumericToNumeric_ShouldReturnExpectedResult(string input, string expected)
+        [MemberData(nameof(AlphaNumericToNumericData), MemberType = typeof(LuhnTest))]
+        public void AlphaNumericToNumeric_ValidInput_ShouldReturnExpectedResult(string input, string expected)
         {
             Assert.Equal(expected, input.AlphaNumericToNumeric());
         }
@@ -297,14 +303,14 @@ namespace LuhnDotNetTest
         /// Tests the AlphaNumericToNumeric method with invalid input.
         /// </summary>
         /// <remarks>
-        /// This test checks if the AlphaNumericToNumeric method throws an ArgumentException when it is given an
+        /// This test checks if the AlphaNumericToNumeric method throws an InvalidCharacterException when it is given an
         /// invalid input string that contains non-alphanumeric characters. The test uses the Assert. Throws method from
         /// xUnit to check if the expected exception is thrown.
         /// </remarks>
         [Fact(DisplayName = "Converts an invalid alphanumeric string to a numeric string to throw an exception")]
-        public void ConvertAlphaNumericToNumeric_InvalidInput_ThrowsArgumentException()
+        public void AlphaNumericToNumeric_InvalidInput_ThrowsInvalidCharacterException()
         {
-            Assert.Throws<ArgumentException>(()=> "!@#$%^&*()".AlphaNumericToNumeric());
+            Assert.Throws<InvalidCharacterException>(()=> "!@#$%^&*()".AlphaNumericToNumeric());
         }
 
         /// <summary>
@@ -328,7 +334,7 @@ namespace LuhnDotNetTest
         /// <param name="expected">Expected output</param>
         [Theory(DisplayName = "Validates a numeric string converted from an alphanumeric string")]
         [MemberData(nameof(IsValidWithConvertData), MemberType = typeof(LuhnTest))]
-        public void IsValidWithConvertTest(string input, bool expected)
+        public void IsValidLuhnNumber_WithAlphaNumericToNumeric_ReturnsExpectedCheckDigit(string input, bool expected)
         {
             Assert.Equal(expected, input.AlphaNumericToNumeric().IsValidLuhnNumber());
             Assert.Equal(expected, input.AlphaNumericToNumeric().AsSpan().IsValidLuhnNumber());
@@ -366,7 +372,7 @@ namespace LuhnDotNetTest
         /// </remarks>
         [Theory(DisplayName = "Calculates the check digit for a valid alphanumeric string")]
         [MemberData(nameof(ComputeLuhnCheckDigitWithConvertData), MemberType = typeof(LuhnTest))]
-        public void ComputeLuhnCheckDigit_WithConvertAlphaNumericToNumeric_ReturnsExpectedCheckDigit(
+        public void ComputeLuhnCheckDigit_WithAlphaNumericToNumeric_ReturnsExpectedCheckDigit(
             string input,
             byte expected)
         {


### PR DESCRIPTION

This pull request introduces a new exception class `InvalidCharacterException` and updates various methods and tests to use this new exception instead of `ArgumentException`. Additionally, it includes renaming and refactoring of test methods for clarity.

### New Exception Class:
* Added `InvalidCharacterException` to handle cases where an input string contains invalid characters. (`src/InvalidCharacterException.cs`)

### Method Updates:
* Replaced `ArgumentException` with `InvalidCharacterException` in the `AlphaNumericToNumeric` and `ValidateAndTrimNumber` methods. (`src/Luhn.cs`) [[1]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL271-R271) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL293-R293) [[3]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL349-R349) [[4]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bL368-R368)

### Test Updates:
* Updated test methods to use `InvalidCharacterException` instead of `ArgumentException`. (`tests/LuhnTest.cs`) [[1]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL215-R221) [[2]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL228-R234) [[3]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL240-R259)
* Renamed test methods for better clarity and consistency. (`tests/LuhnTest.cs`) [[1]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL186-R188) [[2]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL200-R205) [[3]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL264-R270) [[4]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL273-R279) [[5]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL290-R297) [[6]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL305-R313) [[7]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL331-R337) [[8]](diffhunk://#diff-f607f65fe6da6bca0119fee7b3cb4c31113c03ced3afa0c0f0698ea0558f5dfbL369-R375)

### Documentation:
* Updated `CHANGELOG.md` to include the addition of `InvalidCharacterException` and the renaming of `Luhn.ConvertAlphaNumericToNumeric`. (`CHANGELOG.md`)