### PR TITLE
Add `RemoveSeparators` method to process strings without separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `InvalidCharacterException` to throw an exception if the input string contains invalid characters.
+- Add `RemoveSeparators` method to remove all separators from a string. Use it, for example, with credit card numbers.
 
 ### Changed
 - Renamed `Luhn.ConvertAlphaNumericToNumeric` to `Luhn.AlphaNumericToNumeric`

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ namespace Example7
     {
         public static void Main(string[] args)
         {
-            string creditCardNumberWithoutCheckDigit = "4417 1234 5678 911".Replace(" ", "");
+            string creditCardNumberWithoutCheckDigit = "4417 1234 5678 911".RemoveSeparators();
             byte checkDigit = creditCardNumberWithoutCheckDigit.ComputeLuhnCheckDigit();
             Console.WriteLine($"The check digit for credit card number {creditCardNumberWithoutCheckDigit} is: {checkDigit}");
         }
@@ -295,7 +295,7 @@ namespace Example8
     {
         public static void Main(string[] args)
         {
-            string creditCardNumber = "4417 1234 5678 9113".Replace(" ", "");
+            string creditCardNumber = "4417 1234 5678 9113".RemoveSeparators();
             bool isValid = creditCardNumber.IsValidLuhnNumber();
             Console.WriteLine($"The credit card number {creditCardNumber} is valid: {isValid}");
         }

--- a/src/Luhn.cs
+++ b/src/Luhn.cs
@@ -37,8 +37,8 @@ namespace LuhnDotNet
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
-#if !NET8_0_OR_GREATER
     using System.Text;
+#if !NET8_0_OR_GREATER
     using System.Text.RegularExpressions;
 #endif
 
@@ -232,6 +232,34 @@ namespace LuhnDotNet
                 .DoubleEverySecondDigit(true)
                 .SumDigits() == 0;
 #endif
+        }
+
+        /// <summary>
+        /// Removes all separators from the input identifier string.
+        /// </summary>
+        /// <param name="identifier">The input identifier string with separators.</param>
+        /// <returns>The identifier string without separators.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the input identifier is null or empty.</exception>
+        public static string RemoveSeparators(this string identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentNullException(nameof(identifier), "The identifier cannot be null or empty.");
+            }
+
+            // Define valid separators as a HashSet for O(1) lookup
+            var separators = new HashSet<char> { '/', '\\', '-', '_', '|', ',', ' ', '.' };
+            var result = new StringBuilder();
+
+            foreach (char c in identifier)
+            {
+                if (!separators.Contains(c))
+                {
+                    result.Append(c);
+                }
+            }
+
+            return result.ToString();
         }
 
         /// <summary>

--- a/tests/LuhnTest.cs
+++ b/tests/LuhnTest.cs
@@ -379,5 +379,21 @@ namespace LuhnDotNetTest
             Assert.Equal(expected, input.AlphaNumericToNumeric().ComputeLuhnCheckDigit());
             Assert.Equal(expected, input.AlphaNumericToNumeric().AsSpan().ComputeLuhnCheckDigit());
         }
+
+        /// <summary>
+        /// Tests that the RemoveSeparators method processes input correctly by removing separators.
+        /// </summary>
+        /// <param name="input">The input string containing separators.</param>
+        /// <param name="expected">The expected string after separators are removed.</param>
+        [Theory]
+        [InlineData("4444 5555 6666 8888", "4444555566668888")]
+        [InlineData("6666/5555/7777/9123", "6666555577779123")]
+        [InlineData(@"6666\5555\7777\9123", "6666555577779123")]
+        [InlineData("4321-5678-9012-3456", "4321567890123456")]
+        [InlineData("0987654321", "0987654321")]
+        public void RemoveSeparators_ValidInput_ReturnsExpectedResult(string input, string expected)
+        {
+            Assert.Equal(expected, input.RemoveSeparators());
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new method `RemoveSeparators` to the codebase, updates the documentation to reflect this addition, and includes tests to ensure the new method works correctly. The most important changes are summarized below:

### New Method Addition:
* Added `RemoveSeparators` method to remove all separators from a string, useful for processing credit card numbers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10) [[2]](diffhunk://#diff-14f700dd840f81c6bd55aa8605d0651a7f71b9a040fa248acd221b0b27ed851bR237-R264)

### Documentation Updates:
* Updated `README.md` to use the new `RemoveSeparators` method in examples for handling credit card numbers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L277-R277) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L298-R298)

### Testing Enhancements:
* Added tests for the `RemoveSeparators` method to ensure it correctly processes input strings by removing various separators.

### Codebase Maintenance:
* Included `System.Text.RegularExpressions` conditionally based on the target framework version in `src/Luhn.cs`.