### PR TITLE
Hotfix Documentation Generation - Copy benchmark results

### DIFF
--- a/.github/workflows/docfx-build-and-publish.yml
+++ b/.github/workflows/docfx-build-and-publish.yml
@@ -6,6 +6,12 @@ on:
       - LuhnDotNet - Benchmark.Net
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy documentation"
+        required: true
+        default: "staging"
 
 permissions:
   actions: read
@@ -49,7 +55,11 @@ jobs:
           path: benchmark-results
 
       - name: Copy benchmark results to _site
-        run: rsync -av --exclude '.git' benchmark-results/ _site/benchmark-results/
+        run:  -|
+              rsync -av --exclude '.git' helper-benchmark-results/ _site/helper-benchmark-results/
+              rsync -av --exclude '.git' luhn-benchmark-results/ _site/luhn-benchmark-results/
+              rsync -av --exclude '.git' damm-benchmark-results/ _site/damm-benchmark-results/
+              rsync -av --exclude '.git' mod11asc-benchmark-results/ _site/mod11asc-benchmark-results/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/toc.yml
+++ b/toc.yml
@@ -1,4 +1,4 @@
-- name: API-Documentation
+- name: API
   href: api/
 - name: Changelog
   href: CHANGELOG.md


### PR DESCRIPTION
This pull request includes updates to the documentation build and deployment workflow, as well as minor adjustments to the table of contents file. The most notable changes involve enabling manual workflow dispatch with environment selection and refining benchmark result handling in the deployment process.

### Workflow updates:

* [`.github/workflows/docfx-build-and-publish.yml`](diffhunk://#diff-b89304b37c5900be1d32c11a9558cd0804e1fa362306abbdef83c93582988b64R9-R14): Added support for manual workflow dispatch (`workflow_dispatch`) with an input field for selecting the deployment environment, defaulting to "staging."

* [`.github/workflows/docfx-build-and-publish.yml`](diffhunk://#diff-b89304b37c5900be1d32c11a9558cd0804e1fa362306abbdef83c93582988b64L52-R62): Updated the `Copy benchmark results to _site` step to handle multiple benchmark result directories (`helper-benchmark-results`, `luhn-benchmark-results`, `damm-benchmark-results`, and `mod11asc-benchmark-results`) instead of a single directory.

### Table of contents adjustments:

* [`toc.yml`](diffhunk://#diff-ddc0beaf6b98e40781eeef0c0b3697bc273345ecc13cbfc792d4c33cb9b02456L1-R1): Renamed "API-Documentation" to "API" in the table of contents for clarity and conciseness.