### PR TITLE
Refine workflows to include individual benchmark result checkouts

### DIFF
--- a/.github/workflows/benchmarkdotnet.yml
+++ b/.github/workflows/benchmarkdotnet.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'toc.yml'
+      - 'docfx.json'
 
 permissions:
   contents: write

--- a/.github/workflows/docfx-build-and-publish.yml
+++ b/.github/workflows/docfx-build-and-publish.yml
@@ -48,11 +48,29 @@ jobs:
       - name: Run docfx
         run: docfx docfx.json
 
-      - name: Checkout Benchmark Results in subdirectory
+      - name: Checkout Helper Benchmark Results in subdirectory
         uses: actions/checkout@v4
         with:
-          ref: benchmark-results
-          path: benchmark-results
+          ref: helper-benchmark-results
+          path: helper-benchmark-results
+
+      - name: Checkout Luhn Benchmark Results in subdirectory
+        uses: actions/checkout@v4
+        with:
+          ref: luhn-benchmark-results
+          path: luhn-benchmark-results
+
+      - name: Checkout Damm Benchmark Results in subdirectory
+        uses: actions/checkout@v4
+        with:
+          ref: damm-benchmark-results
+          path: damm-benchmark-results
+
+      - name: Checkout Mod11 Asc Benchmark Results in subdirectory
+        uses: actions/checkout@v4
+        with:
+          ref: mod11asc-benchmark-results
+          path: mod11asc-benchmark-results
 
       - name: Copy benchmark results to _site
         run:  -|


### PR DESCRIPTION
This pull request introduces changes to GitHub Actions workflows, focusing on optimizing triggers and enhancing the handling of benchmark results. The most important changes include ignoring documentation files in the `push` trigger for the BenchmarkDotNet workflow and expanding the `docfx-build-and-publish` workflow to handle multiple benchmark result directories.

### Workflow trigger optimization:

* [`.github/workflows/benchmarkdotnet.yml`](diffhunk://#diff-9dc440ea1122d1a443cecad0ea416f99a1afdb5220b59dedd37f3d9c2d201091R6-R9): Updated the `push` trigger to ignore changes to documentation files (`.md`, `toc.yml`, `docfx.json`) to prevent unnecessary workflow runs.

### Benchmark results handling:

* [`.github/workflows/docfx-build-and-publish.yml`](diffhunk://#diff-b89304b37c5900be1d32c11a9558cd0804e1fa362306abbdef83c93582988b64L51-R73): Added steps to check out additional benchmark result directories (`helper-benchmark-results`, `luhn-benchmark-results`, `damm-benchmark-results`, `mod11asc-benchmark-results`) for better organization and processing. Renamed the existing step to "Checkout Helper Benchmark Results" for clarity.