### PR TITLE
Fix indentation in rsync commands in `docfx-build-and-publish.yml`

### DIFF
--- a/.github/workflows/docfx-build-and-publish.yml
+++ b/.github/workflows/docfx-build-and-publish.yml
@@ -73,11 +73,11 @@ jobs:
           path: mod11asc-benchmark-results
 
       - name: Copy benchmark results to _site
-        run:  -|
-              rsync -av --exclude '.git' helper-benchmark-results/ _site/helper-benchmark-results/
-              rsync -av --exclude '.git' luhn-benchmark-results/ _site/luhn-benchmark-results/
-              rsync -av --exclude '.git' damm-benchmark-results/ _site/damm-benchmark-results/
-              rsync -av --exclude '.git' mod11asc-benchmark-results/ _site/mod11asc-benchmark-results/
+        run: |
+          rsync -av --exclude '.git' helper-benchmark-results/ _site/helper-benchmark-results/
+          rsync -av --exclude '.git' luhn-benchmark-results/ _site/luhn-benchmark-results/
+          rsync -av --exclude '.git' damm-benchmark-results/ _site/damm-benchmark-results/
+          rsync -av --exclude '.git' mod11asc-benchmark-results/ _site/mod11asc-benchmark-results/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/docfx-build-and-publish.yml` file. The change simplifies the `run` command syntax by removing the redundant `-|` indicator in the script definition.